### PR TITLE
fix: Close browser after use

### DIFF
--- a/src/runtime/nitro/renderers/browser.ts
+++ b/src/runtime/nitro/renderers/browser.ts
@@ -15,11 +15,16 @@ export default <Renderer> {
     const createBrowser = await loadBrowser()
     const browser = await createBrowser()
     if (browser) {
-      return screenshot(browser!, {
-        ...options,
-        host: url.origin,
-        path: `/api/og-image-html?path=${url.pathname}`,
-      })
+      try {
+        return await screenshot(browser!, {
+          ...options,
+          host: url.origin,
+          path: `/api/og-image-html?path=${url.pathname}`,
+        })
+      }
+      finally {
+        browser!.close()
+      }
     }
     return null
   },


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, after making a screenshot, the browser does not close, which generates a lot of processes and leads to memory leaks. This pull-request adds closing the browser after taking a screenshot

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
