### PR TITLE
feat: support locally loaded custom fonts

### DIFF
--- a/.playground/components/islands/CustomFontTemplate.vue
+++ b/.playground/components/islands/CustomFontTemplate.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+const props = defineProps({
+  path: String,
+  title: String,
+  description: String,
+  themeColor: String,
+  appName: String
+})
+
+const theme = computed(() => props.themeColor || '#dbf4ff')
+</script>
+
+<template>
+<div :style="{ fontFamily: 'optieinstein', fontWeight: 400, padding: '0 60px', width: '100%', height: '100%', backgroundColor: '#0c0c0c', backgroundImage: 'linear-gradient(to bottom, ' + theme + ', #fff1f1)', display: 'flex', alignItems: 'center' }">
+  <div :style="{ padding: '0 30px', display: 'flex', flexDirection: 'column' }">
+    <p :style="{ fontSize: '75px', fontWeight: 'bold', marginBottom: '20px' }">{{ title }}</p>
+    <p :style="{ fontSize: '35px', fontWeight: 400 }">{{ description }}</p>
+  </div>
+  <div :style="{ position: 'absolute', top: '50px', left: '50px', fontSize: '40px', fontWeight: 300 }">{{ appName }}</div>
+</div>
+</template>

--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -34,6 +34,15 @@ export default defineNuxtConfig({
 
 
   ogImage: {
+    fonts: [
+      'Inter:400',
+      'Inter:700',
+      {
+        name: 'optieinstein',
+        weight: 800,
+        path: '/OPTIEinstein-Black.otf',
+      }
+    ],
     playground: true,
     runtimeCacheStorage: false,
     defaults: {

--- a/.playground/pages/index.vue
+++ b/.playground/pages/index.vue
@@ -94,6 +94,10 @@ const { data: posts } = await useFetch('/api/posts')
           <div class="mb-2">Image</div>
           <img :src="`${host}satori/image/__og_image__/og.png`" width="400" height="210" class="rounded" />
         </NuxtLink>
+        <NuxtLink external no-prefetch to="/satori/custom-font/__og_image__/og.png" target="_blank">
+          <div class="mb-2">Custom Font</div>
+          <img :src="`${host}satori/custom-font/__og_image__/og.png`" width="400" height="210" class="rounded" />
+        </NuxtLink>
       </div>
     </div>
     <div class="col-span-2">

--- a/.playground/pages/satori/custom-font.vue
+++ b/.playground/pages/satori/custom-font.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const description = 'Using a custom font loaded from the public directory.'
+</script>
+<template>
+  <div>
+    <div>
+      Custom font page
+    </div>
+    <OgImageStatic component="CustomFontTemplate" title="Custom Font" :description="description" />
+  </div>
+</template>

--- a/README.md
+++ b/README.md
@@ -354,8 +354,22 @@ _package.json_
 
 ## Custom Fonts / Supporting non-english characters
 
-When creating your OG Image, you'll probably want to use a font custom to your project. The module allows you to use any Google font
-with minimal config.
+When creating your OG Image, you'll probably want to use a font custom to your project. 
+
+To make this easier for you, Google Fonts are loaded by default with Inter 400 and Inter 700. 
+
+You can easily load different Google Fonts by using their name+weight. For example:
+
+```ts
+export default defineNuxtConfig({
+  ogImage: {
+    fonts: [
+      // will load the Noto Sans font from Google fonts
+      'Noto+Sans:400'
+    ]
+  }
+})
+```
 
 This also lets you support non-english characters by adding the appropriate font to your config.
 
@@ -371,6 +385,34 @@ export default defineNuxtConfig({
   }
 })
 ````
+
+If you'd like to load a font locally,
+then you can provide the configuration as an object:
+
+```ts
+export default defineNuxtConfig({
+  ogImage: {
+    fonts: [
+      {
+        name: 'optieinstein',
+        weight: 800,
+        // path must point to a public font file
+        path: '/OPTIEinstein-Black.otf',
+      }
+    ],
+  }
+})
+```
+
+Make sure to set the font family in your component to match the font name.
+
+```vue
+<template>
+<div :style="{ fontFamily: 'optieinstein' }">
+  <!-- Your component  -->
+</div>
+</template>
+```
 
 ## Caching
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,7 +22,7 @@ import { copy, mkdirp, pathExists } from 'fs-extra'
 import { globby } from 'globby'
 import createBrowser from './runtime/nitro/providers/browser/universal'
 import { screenshot } from './runtime/browserUtil'
-import type { OgImageOptions, ScreenshotOptions } from './types'
+import type { FontConfig, OgImageOptions, ScreenshotOptions } from './types'
 import { setupPlaygroundRPC } from './rpc'
 import { extractOgImageOptions } from './runtime/nitro/utils-pure'
 import { Wasms } from './const'
@@ -39,7 +39,7 @@ export interface ModuleOptions {
    */
   siteUrl?: string
   defaults: OgImageOptions
-  fonts: `${string}:${number}`[]
+  fonts: FontConfig[]
   satoriOptions: Partial<SatoriOptions>
   playground: boolean
   runtimeSatori: boolean

--- a/src/runtime/nitro/renderers/satori/index.ts
+++ b/src/runtime/nitro/renderers/satori/index.ts
@@ -1,7 +1,7 @@
 import { html as convertHtmlToSatori } from 'satori-html'
 import { parseURL } from 'ufo'
 import twemoji from 'twemoji'
-import type { Renderer } from '../../../../types'
+import type { FontConfig, Renderer } from '../../../../types'
 import { loadFont, walkSatoriTree } from './utils'
 import imageSrc from './plugins/imageSrc'
 import twClasses from './plugins/twClasses'
@@ -14,7 +14,7 @@ import { useNitroApp, useRuntimeConfig } from '#internal/nitro'
 
 const satoriFonts: any[] = []
 let fontLoadPromise: Promise<any> | null = null
-function loadFonts(fonts: string[]) {
+function loadFonts(fonts: FontConfig[]) {
   if (fontLoadPromise)
     return fontLoadPromise
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface OgImageOptions extends Partial<ScreenshotOptions> {
   [key: string]: any
 }
 
+export type FontConfig = (`${string}:${number}` | { name: string; weight: number; path: string })
 export interface Renderer {
   name: 'browser' | 'satori'
   createSvg: (path: string, options: OgImageOptions) => Promise<string>


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allows custom local fonts to be loaded easily through the config.

```ts
 ogImage: {
    fonts: [
      {
        name: 'optieinstein',
        weight: 800,
        path: '/OPTIEinstein-Black.otf',
      }
  ]
}
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/harlan-zw/nuxt-og-image/issues/42


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
