### PR TITLE
fix(fallback): add missing import for `resolveComponent`

### DIFF
--- a/src/runtime/components/OgImageTemplate/Fallback.vue
+++ b/src/runtime/components/OgImageTemplate/Fallback.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, resolveComponent } from 'vue'
 import { useSiteConfig } from '#imports'
 
 // inherited attrs can mess up the satori parser


### PR DESCRIPTION
### Description

The component would otherwise error because the method would not be found.

### Linked Issues

n/a

### Additional context

n/a
