### PR TITLE
fix(composable): allow for undefined `currentRoute`

### DIFF
--- a/src/runtime/composables/defineOgImage.ts
+++ b/src/runtime/composables/defineOgImage.ts
@@ -7,7 +7,7 @@ import { useRouter, useRuntimeConfig, useServerHead, withSiteUrl } from '#import
 
 export function defineOgImageScreenshot(options: OgImageScreenshotOptions = {}) {
   const router = useRouter()
-  const route = router?.currentRoute?.value?.path || ''
+  const route = router.currentRoute.value?.path || ''
   return defineOgImage({
     alt: `Web page screenshot${route ? ` of ${route}` : ''}.`,
     provider: 'browser',
@@ -57,7 +57,7 @@ export async function defineOgImage(_options: OgImageOptions = {}) {
     const options = normaliseOgImageOptions(_options)
     const optionsWithDefault = defu(options, defaults)
 
-    const src = withSiteUrl(joinURL(useRouter().currentRoute.value.path || '', '/__og_image__/og.png'))
+    const src = withSiteUrl(joinURL(useRouter().currentRoute.value?.path || '', '/__og_image__/og.png'))
 
     const meta: Head['meta'] = [
       { property: 'og:image', content: src },


### PR DESCRIPTION
### Description

`currentRoute` can be undefined, for which a check already exists, but not in all places.

### Linked Issues
n/a

### Additional context

n/a
