### PR TITLE
fix(utils-pure): generalize script matcher

### DIFF
--- a/src/runtime/nitro/utils-pure.ts
+++ b/src/runtime/nitro/utils-pure.ts
@@ -30,7 +30,7 @@ function decodeObjectHtmlEntities(obj: Record<string, string | any>) {
 }
 export function extractAndNormaliseOgImageOptions(path: string, html: string, routeRules: OgImageOptions, defaults: OgImageOptions): OgImageOptions | false {
   // extract the options from our script tag
-  const htmlPayload = html.match(/<script id="nuxt-og-image-options" type="application\/json">(.+?)<\/script>/)?.[1]
+  const htmlPayload = html.match(/<script.+id="nuxt-og-image-options"[^>]*>(.+?)<\/script>/)?.[1]
   if (!htmlPayload)
     return false
 


### PR DESCRIPTION
### Description

There might be a `nonce` attribute added to script tags, e.g. by `nuxt-security`, which makes the regex not match the script tag anymore. This change loosens the regex a bit so that it only checks for the script's `id`, which should be unique.

### Linked Issues

n/a

### Additional context

n/a
