### PR TITLE
fix: sync Cache-Control header time with options

### DIFF
--- a/src/runtime/nitro/middleware/og.png.ts
+++ b/src/runtime/nitro/middleware/og.png.ts
@@ -64,7 +64,7 @@ export default defineEventHandler(async (e) => {
 
   if (png) {
     if (cacheEnabled) {
-      setHeader(e, 'Cache-Control', 'public, max-age=31536000')
+      setHeader(e, 'Cache-Control', 'public, max-age=' + options.cacheTtl || 0)
     }
     else {
       // add http headers so the file isn't cached

--- a/src/runtime/nitro/middleware/og.png.ts
+++ b/src/runtime/nitro/middleware/og.png.ts
@@ -63,8 +63,8 @@ export default defineEventHandler(async (e) => {
   }
 
   if (png) {
-    if (cacheEnabled) {
-      setHeader(e, 'Cache-Control', 'public, max-age=' + options.cacheTtl || 0)
+    if (cacheEnabled && options.cacheTtl) {
+      setHeader(e, 'Cache-Control', `public, max-age=${options.cacheTtl}`)
     }
     else {
       // add http headers so the file isn't cached


### PR DESCRIPTION
Currently, the cache is forced to 365 days; I have adjusted it with the custom-defined value.