### PR TITLE
fix(module.ts): repeated 'ctx' parameter in nuxt-og-image:satori:vnod…

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -428,7 +428,7 @@ declare module 'nitropack' {
   }
   interface NitroRuntimeHooks {
     'nuxt-og-image:context': (ctx: import('${typesPath}').OgImageRenderEventContext) => void | Promise<void>
-    'nuxt-og-image:satori:vnodes': (vnodes: import('${typesPath}').VNode, ctx: ctx: import('${typesPath}').OgImageRenderEventContext) => void | Promise<void>
+    'nuxt-og-image:satori:vnodes': (vnodes: import('${typesPath}').VNode, ctx: import('${typesPath}').OgImageRenderEventContext) => void | Promise<void>
   }
 }
 


### PR DESCRIPTION
### Description

This PR addresses a minor typo in the type declaration of the nuxt-og-image:satori:vnodes event. Specifically, the ctx parameter was mistakenly duplicated in the function's parameters. This fix removes the redundant occurrence, ensuring the correct type declaration.

### Linked Issues

(None identified. If this PR relates to an existing issue, please link it here.)